### PR TITLE
Fixed the collision detection in turret behavior

### DIFF
--- a/AlmostRace-Capstone/Assets/Scripts/Abilities/Projectile.cs
+++ b/AlmostRace-Capstone/Assets/Scripts/Abilities/Projectile.cs
@@ -90,7 +90,7 @@ public abstract class Projectile : MonoBehaviour
         _isAlive = false;
         _rigidBody.velocity = Vector3.zero;
         _rigidBody.useGravity = false;
-        _rigidBody.isKinematic = true;
+       // _rigidBody.isKinematic = true;
          meshRenderer.enabled = false;     
             yield return null;
         Destroy(gameObject);

--- a/AlmostRace-Capstone/Assets/Scripts/Hazards/Turret/TurretBehavior.cs
+++ b/AlmostRace-Capstone/Assets/Scripts/Hazards/Turret/TurretBehavior.cs
@@ -136,7 +136,7 @@ public class TurretBehavior : Interactable
     {
         if(currentTarget != null)
         {
-
+            //  Debug.Log("Turret should be aiming");
             /*if (m_lastKnownPosition != currentTarget.transform.position)
             {
                 m_lastKnownPosition = currentTarget.transform.position;
@@ -151,6 +151,9 @@ public class TurretBehavior : Interactable
             Vector3 pos = predictedPosition(currentTarget.transform.position, turretMuzzle.position, currentTarget.GetComponent<RaycastCar>().GetRelativeVelocity(), turretProjectileSpeed);
 
             turretHead.LookAt(pos);//look at current target
+
+
+            //turretHead.LookAt(currentTarget.transform);
         }
         else
         {
@@ -176,16 +179,20 @@ public class TurretBehavior : Interactable
 
     public void FireTurret()
     {
+        Debug.Log("Turret should be firing!");
         AudioManager.instance.Play("Turret Shot", transform);//play firing sound
         GameObject spawnedProjectile = Instantiate(turretProjectile, turretMuzzle.position, turretMuzzle.rotation);//fire projectile at current target
         if(!shootsBoulders)
         {
-            spawnedProjectile.GetComponent<TurretProjectileBehavior>().SetProjectileInfo(turretProjectileDamage, turretProjectileSpeed, gameObject);
+            spawnedProjectile.GetComponent<TurretProjectileBehavior>().SetProjectileInfo(turretProjectileDamage, turretProjectileSpeed, gameObject, aggroObject);
+           // Debug.Log("Turret fired a laser!");
 
         }
         else
         {
             spawnedProjectile.GetComponent<Rigidbody>().velocity = transform.TransformDirection(Vector3.forward * turretProjectileSpeed);
+           // Debug.Log("Turret fired a boulder!");
+
         }
         if (spraysBullets && !shootsBoulders)
         {
@@ -193,7 +200,7 @@ public class TurretBehavior : Interactable
             for(int i = 0; i < extraBulletsToSpray; i++)
             {
                 GameObject extraSpawnedProjectile = Instantiate(turretProjectile, turretMuzzle.position, turretMuzzle.rotation);//fire projectile at current target
-                extraSpawnedProjectile.GetComponent<TurretProjectileBehavior>().SetProjectileInfo(turretProjectileDamage, turretProjectileSpeed, gameObject);
+                extraSpawnedProjectile.GetComponent<TurretProjectileBehavior>().SetProjectileInfo(turretProjectileDamage, turretProjectileSpeed, gameObject, aggroObject);
                 extraSpawnedProjectile.transform.Rotate(Random.Range(-.5f, .5f), Random.Range(-2,2), Random.Range(-.5f, .5f));
             }
            

--- a/AlmostRace-Capstone/Assets/Scripts/Hazards/Turret/TurretBehavior2.cs
+++ b/AlmostRace-Capstone/Assets/Scripts/Hazards/Turret/TurretBehavior2.cs
@@ -178,14 +178,14 @@ public class TurretBehavior2 : Interactable
             else
             {
                 GameObject spawnedProjectile = Instantiate(turretProjectile, turretMuzzle.position, turretMuzzle.rotation);//fire projectile at current target
-                spawnedProjectile.GetComponent<TurretProjectileBehavior>().SetProjectileInfo(turretProjectileDamage, turretProjectileSpeed, gameObject);
+                spawnedProjectile.GetComponent<TurretProjectileBehavior>().SetProjectileInfo(turretProjectileDamage, turretProjectileSpeed, gameObject, aggroObject);
                 if (spraysBullets)
                 {
 
                     for (int i = 0; i < extraBulletsToSpray; i++)
                     {
                         GameObject extraSpawnedProjectile = Instantiate(turretProjectile, turretMuzzle.position, turretMuzzle.rotation);//fire projectile at current target
-                        extraSpawnedProjectile.GetComponent<TurretProjectileBehavior>().SetProjectileInfo(turretProjectileDamage, turretProjectileSpeed, gameObject);
+                        extraSpawnedProjectile.GetComponent<TurretProjectileBehavior>().SetProjectileInfo(turretProjectileDamage, turretProjectileSpeed, gameObject , aggroObject);
                         extraSpawnedProjectile.transform.Rotate(Random.Range(-.5f, .5f), Random.Range(-2, 2), Random.Range(-.5f, .5f));
                     }
                 }

--- a/AlmostRace-Capstone/Assets/Scripts/Hazards/Turret/TurretBehavior3.cs
+++ b/AlmostRace-Capstone/Assets/Scripts/Hazards/Turret/TurretBehavior3.cs
@@ -179,14 +179,14 @@ public class TurretBehavior3 : Interactable
             else
             {
                 GameObject spawnedProjectile = Instantiate(turretProjectile, turretMuzzle.position, turretMuzzle.rotation);//fire projectile at current target
-                spawnedProjectile.GetComponent<TurretProjectileBehavior>().SetProjectileInfo(turretProjectileDamage, turretProjectileSpeed, gameObject);
+                spawnedProjectile.GetComponent<TurretProjectileBehavior>().SetProjectileInfo(turretProjectileDamage, turretProjectileSpeed, gameObject, aggroObject);
                 if (spraysBullets)
                 {
 
                     for (int i = 0; i < extraBulletsToSpray; i++)
                     {
                         GameObject extraSpawnedProjectile = Instantiate(turretProjectile, turretMuzzle.position, turretMuzzle.rotation);//fire projectile at current target
-                        extraSpawnedProjectile.GetComponent<TurretProjectileBehavior>().SetProjectileInfo(turretProjectileDamage, turretProjectileSpeed, gameObject);
+                        extraSpawnedProjectile.GetComponent<TurretProjectileBehavior>().SetProjectileInfo(turretProjectileDamage, turretProjectileSpeed, gameObject, aggroObject);
                         extraSpawnedProjectile.transform.Rotate(Random.Range(-.5f, .5f), Random.Range(-2, 2), Random.Range(-.5f, .5f));
                     }
                 }

--- a/AlmostRace-Capstone/Assets/Scripts/Hazards/Turret/TurretProjectileBehavior.cs
+++ b/AlmostRace-Capstone/Assets/Scripts/Hazards/Turret/TurretProjectileBehavior.cs
@@ -11,22 +11,25 @@ using Cinemachine;
 
 public class TurretProjectileBehavior : Projectile
 {
-
+    private GameObject _aggroObject;
     public void Start()
     {
         GiveSpeed();
     }
 
-    public void SetProjectileInfo(float projectileDamage, float projectileSpeed, GameObject immunePlayer)
+    public void SetProjectileInfo(float projectileDamage, float projectileSpeed, GameObject immunePlayer, GameObject aggroObject)
     {
         _projectileDamage = projectileDamage;
         _projectileSpeed = projectileSpeed;
         _immunePlayer = immunePlayer;
+        _aggroObject = aggroObject;
     }
 
     private void OnTriggerEnter(Collider other)
     {
-        if (other.gameObject.GetComponent<Interactable>() != null)
+
+        Debug.Log("laserbolt collided with: " + other.gameObject.name);
+        if (other.gameObject.GetComponent<Interactable>() != null && other.gameObject != _aggroObject)
         {//Checks if the object isn't the immunePlayer and if they are an interactable object.
 
             if (!other.gameObject.CompareTag("Projectile"))
@@ -55,7 +58,7 @@ public class TurretProjectileBehavior : Projectile
         }
         else
         {
-            StartCoroutine(ExplosionEffect());
+            Destroy(gameObject, 10);
         }
 
 


### PR DESCRIPTION
Turret projectiles collided with the turret aggrosphere and destroyed themselves immediately. This has been fixed across the 3 turret scripts. If using/placing turrets, use Turret_Legacy