### PR TITLE
Added code to affect boost max turn angle

### DIFF
--- a/AlmostRace-Capstone/Assets/Prefabs/Cars/Lux/Vehicle_Lux_2.0.prefab
+++ b/AlmostRace-Capstone/Assets/Prefabs/Cars/Lux/Vehicle_Lux_2.0.prefab
@@ -33064,7 +33064,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   selfHeatDamage: 0
-  boostSpeedPercentage: 0.25
+  boostSpeedPercentage: 25
+  maxBoostTurnAngle: 50
   jetParticles: {fileID: 7992591043427854818}
   jetParticles2: {fileID: 2729144522342871850}
   jetParticles3: {fileID: 4081412170243074297}
@@ -66729,12 +66730,12 @@ PrefabInstance:
     - target: {fileID: 644788422693019630, guid: 28eb1ec0d234c8d49b746c202b4fabd8,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0.000000028248484
+      value: 0.000000017093273
       objectReference: {fileID: 0}
     - target: {fileID: 644788422693019630, guid: 28eb1ec0d234c8d49b746c202b4fabd8,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: -0.00000011810117
+      value: -0.00000011646393
       objectReference: {fileID: 0}
     - target: {fileID: 644788422693019630, guid: 28eb1ec0d234c8d49b746c202b4fabd8,
         type: 3}

--- a/AlmostRace-Capstone/Assets/Prefabs/Cars/PainTrain/Vehicle_PainTrain.prefab
+++ b/AlmostRace-Capstone/Assets/Prefabs/Cars/PainTrain/Vehicle_PainTrain.prefab
@@ -2278,6 +2278,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   selfHeatDamage: 0
   boostField: {fileID: 1227828136789151717}
+  boostSpeedPercentage: 30
+  maxBoostTurnAngle: 20
   boostDamageRate: 0.5
   boostDamage: 10
   smallSize: 1
@@ -2289,7 +2291,6 @@ MonoBehaviour:
   boosterParticles:
   - {fileID: 3411650648341756680}
   - {fileID: 8685050092641224338}
-  boostSpeedPercentage: 0.3
 --- !u!114 &5530304377845725064
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -4775,15 +4776,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: c9047090688c1c74fae6cdf1ef6b516e, type: 3}
---- !u!198 &2363779911712138032 stripped
-ParticleSystem:
-  m_CorrespondingSourceObject: {fileID: 19800000, guid: c9047090688c1c74fae6cdf1ef6b516e,
-    type: 3}
-  m_PrefabInstance: {fileID: 2363779911730101488}
-  m_PrefabAsset: {fileID: 0}
 --- !u!4 &2363779911730488948 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 400004, guid: c9047090688c1c74fae6cdf1ef6b516e,
+    type: 3}
+  m_PrefabInstance: {fileID: 2363779911730101488}
+  m_PrefabAsset: {fileID: 0}
+--- !u!198 &2363779911712138032 stripped
+ParticleSystem:
+  m_CorrespondingSourceObject: {fileID: 19800000, guid: c9047090688c1c74fae6cdf1ef6b516e,
     type: 3}
   m_PrefabInstance: {fileID: 2363779911730101488}
   m_PrefabAsset: {fileID: 0}
@@ -5240,15 +5241,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: c9047090688c1c74fae6cdf1ef6b516e, type: 3}
---- !u!198 &2597986241567074064 stripped
-ParticleSystem:
-  m_CorrespondingSourceObject: {fileID: 19800000, guid: c9047090688c1c74fae6cdf1ef6b516e,
-    type: 3}
-  m_PrefabInstance: {fileID: 2597986241548597456}
-  m_PrefabAsset: {fileID: 0}
 --- !u!4 &2597986241548722772 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 400004, guid: c9047090688c1c74fae6cdf1ef6b516e,
+    type: 3}
+  m_PrefabInstance: {fileID: 2597986241548597456}
+  m_PrefabAsset: {fileID: 0}
+--- !u!198 &2597986241567074064 stripped
+ParticleSystem:
+  m_CorrespondingSourceObject: {fileID: 19800000, guid: c9047090688c1c74fae6cdf1ef6b516e,
     type: 3}
   m_PrefabInstance: {fileID: 2597986241548597456}
   m_PrefabAsset: {fileID: 0}
@@ -6486,15 +6487,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: c9047090688c1c74fae6cdf1ef6b516e, type: 3}
---- !u!198 &3657381458852572440 stripped
-ParticleSystem:
-  m_CorrespondingSourceObject: {fileID: 19800000, guid: c9047090688c1c74fae6cdf1ef6b516e,
-    type: 3}
-  m_PrefabInstance: {fileID: 3657381458838811352}
-  m_PrefabAsset: {fileID: 0}
 --- !u!4 &3657381458838415452 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 400004, guid: c9047090688c1c74fae6cdf1ef6b516e,
+    type: 3}
+  m_PrefabInstance: {fileID: 3657381458838811352}
+  m_PrefabAsset: {fileID: 0}
+--- !u!198 &3657381458852572440 stripped
+ParticleSystem:
+  m_CorrespondingSourceObject: {fileID: 19800000, guid: c9047090688c1c74fae6cdf1ef6b516e,
     type: 3}
   m_PrefabInstance: {fileID: 3657381458838811352}
   m_PrefabAsset: {fileID: 0}
@@ -6968,16 +6969,6 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 3894711990671703987}
     m_Modifications:
-    - target: {fileID: -927199367670048503, guid: 0eea216e429a6ed4cbc0f747362f853f,
-        type: 3}
-      propertyPath: m_Name
-      value: _ Pain Train Ribcage Unwrapped
-      objectReference: {fileID: 0}
-    - target: {fileID: -927199367670048503, guid: 0eea216e429a6ed4cbc0f747362f853f,
-        type: 3}
-      propertyPath: m_IsActive
-      value: 1
-      objectReference: {fileID: 0}
     - target: {fileID: -4216859302048453862, guid: 0eea216e429a6ed4cbc0f747362f853f,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -7047,6 +7038,16 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalScale.z
       value: 0.83333325
+      objectReference: {fileID: 0}
+    - target: {fileID: -927199367670048503, guid: 0eea216e429a6ed4cbc0f747362f853f,
+        type: 3}
+      propertyPath: m_Name
+      value: _ Pain Train Ribcage Unwrapped
+      objectReference: {fileID: 0}
+    - target: {fileID: -927199367670048503, guid: 0eea216e429a6ed4cbc0f747362f853f,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: -1504981713932161579, guid: 0eea216e429a6ed4cbc0f747362f853f,
         type: 3}
@@ -7225,16 +7226,6 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 3894711990671703987}
     m_Modifications:
-    - target: {fileID: -927199367670048503, guid: e203ebe5144b65f4484d541ca6bc7852,
-        type: 3}
-      propertyPath: m_Name
-      value: One Pair of Ribs (1)
-      objectReference: {fileID: 0}
-    - target: {fileID: -927199367670048503, guid: e203ebe5144b65f4484d541ca6bc7852,
-        type: 3}
-      propertyPath: m_IsActive
-      value: 0
-      objectReference: {fileID: 0}
     - target: {fileID: -4216859302048453862, guid: e203ebe5144b65f4484d541ca6bc7852,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -7304,6 +7295,16 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalScale.z
       value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -927199367670048503, guid: e203ebe5144b65f4484d541ca6bc7852,
+        type: 3}
+      propertyPath: m_Name
+      value: One Pair of Ribs (1)
+      objectReference: {fileID: 0}
+    - target: {fileID: -927199367670048503, guid: e203ebe5144b65f4484d541ca6bc7852,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: -1504981713932161579, guid: e203ebe5144b65f4484d541ca6bc7852,
         type: 3}
@@ -9357,16 +9358,6 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 3894711990671703987}
     m_Modifications:
-    - target: {fileID: -927199367670048503, guid: e203ebe5144b65f4484d541ca6bc7852,
-        type: 3}
-      propertyPath: m_Name
-      value: One Pair of Ribs
-      objectReference: {fileID: 0}
-    - target: {fileID: -927199367670048503, guid: e203ebe5144b65f4484d541ca6bc7852,
-        type: 3}
-      propertyPath: m_IsActive
-      value: 0
-      objectReference: {fileID: 0}
     - target: {fileID: -4216859302048453862, guid: e203ebe5144b65f4484d541ca6bc7852,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -9436,6 +9427,16 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalScale.z
       value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -927199367670048503, guid: e203ebe5144b65f4484d541ca6bc7852,
+        type: 3}
+      propertyPath: m_Name
+      value: One Pair of Ribs
+      objectReference: {fileID: 0}
+    - target: {fileID: -927199367670048503, guid: e203ebe5144b65f4484d541ca6bc7852,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: -1504981713932161579, guid: e203ebe5144b65f4484d541ca6bc7852,
         type: 3}
@@ -9764,15 +9765,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: c9047090688c1c74fae6cdf1ef6b516e, type: 3}
---- !u!198 &7620142224147747432 stripped
-ParticleSystem:
-  m_CorrespondingSourceObject: {fileID: 19800000, guid: c9047090688c1c74fae6cdf1ef6b516e,
-    type: 3}
-  m_PrefabInstance: {fileID: 7620142224166489512}
-  m_PrefabAsset: {fileID: 0}
 --- !u!4 &7620142224166098732 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 400004, guid: c9047090688c1c74fae6cdf1ef6b516e,
+    type: 3}
+  m_PrefabInstance: {fileID: 7620142224166489512}
+  m_PrefabAsset: {fileID: 0}
+--- !u!198 &7620142224147747432 stripped
+ParticleSystem:
+  m_CorrespondingSourceObject: {fileID: 19800000, guid: c9047090688c1c74fae6cdf1ef6b516e,
     type: 3}
   m_PrefabInstance: {fileID: 7620142224166489512}
   m_PrefabAsset: {fileID: 0}
@@ -9923,15 +9924,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: c9047090688c1c74fae6cdf1ef6b516e, type: 3}
---- !u!198 &7704913828414803858 stripped
-ParticleSystem:
-  m_CorrespondingSourceObject: {fileID: 19800000, guid: c9047090688c1c74fae6cdf1ef6b516e,
-    type: 3}
-  m_PrefabInstance: {fileID: 7704913828395798610}
-  m_PrefabAsset: {fileID: 0}
 --- !u!4 &7704913828395403990 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 400004, guid: c9047090688c1c74fae6cdf1ef6b516e,
+    type: 3}
+  m_PrefabInstance: {fileID: 7704913828395798610}
+  m_PrefabAsset: {fileID: 0}
+--- !u!198 &7704913828414803858 stripped
+ParticleSystem:
+  m_CorrespondingSourceObject: {fileID: 19800000, guid: c9047090688c1c74fae6cdf1ef6b516e,
     type: 3}
   m_PrefabInstance: {fileID: 7704913828395798610}
   m_PrefabAsset: {fileID: 0}
@@ -10241,15 +10242,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: c9047090688c1c74fae6cdf1ef6b516e, type: 3}
---- !u!198 &8220869882629652466 stripped
-ParticleSystem:
-  m_CorrespondingSourceObject: {fileID: 19800000, guid: c9047090688c1c74fae6cdf1ef6b516e,
-    type: 3}
-  m_PrefabInstance: {fileID: 8220869882648387634}
-  m_PrefabAsset: {fileID: 0}
 --- !u!4 &8220869882648001206 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 400004, guid: c9047090688c1c74fae6cdf1ef6b516e,
+    type: 3}
+  m_PrefabInstance: {fileID: 8220869882648387634}
+  m_PrefabAsset: {fileID: 0}
+--- !u!198 &8220869882629652466 stripped
+ParticleSystem:
+  m_CorrespondingSourceObject: {fileID: 19800000, guid: c9047090688c1c74fae6cdf1ef6b516e,
     type: 3}
   m_PrefabInstance: {fileID: 8220869882648387634}
   m_PrefabAsset: {fileID: 0}
@@ -10480,37 +10481,32 @@ PrefabInstance:
     - target: {fileID: 644788422693019630, guid: 28eb1ec0d234c8d49b746c202b4fabd8,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: -0.18910752
+      value: -0.14521314
       objectReference: {fileID: 0}
     - target: {fileID: 644788422693019630, guid: 28eb1ec0d234c8d49b746c202b4fabd8,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0.00000003773145
+      value: 0.000000028248484
       objectReference: {fileID: 0}
     - target: {fileID: 644788422693019630, guid: 28eb1ec0d234c8d49b746c202b4fabd8,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: -0.00000012208541
+      value: -0.00000011810113
       objectReference: {fileID: 0}
     - target: {fileID: 644788422693019630, guid: 28eb1ec0d234c8d49b746c202b4fabd8,
         type: 3}
       propertyPath: m_LocalRotation.w
-      value: -0.9819564
+      value: -0.98940045
       objectReference: {fileID: 0}
     - target: {fileID: 644788422693019630, guid: 28eb1ec0d234c8d49b746c202b4fabd8,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 5
+      value: 3.75
       objectReference: {fileID: 0}
     - target: {fileID: 644788422693019630, guid: 28eb1ec0d234c8d49b746c202b4fabd8,
         type: 3}
       propertyPath: m_LocalPosition.z
       value: -12.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 2329687056888948350, guid: 28eb1ec0d234c8d49b746c202b4fabd8,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 7
       objectReference: {fileID: 0}
     - target: {fileID: 3240311213283490686, guid: 28eb1ec0d234c8d49b746c202b4fabd8,
         type: 3}
@@ -10527,50 +10523,10 @@ PrefabInstance:
       propertyPath: boostAbility
       value: 
       objectReference: {fileID: 3339663664685297937}
-    - target: {fileID: 570438915209207995, guid: 28eb1ec0d234c8d49b746c202b4fabd8,
+    - target: {fileID: 8574603337716842063, guid: 28eb1ec0d234c8d49b746c202b4fabd8,
         type: 3}
-      propertyPath: m_RootOrder
-      value: 8
-      objectReference: {fileID: 0}
-    - target: {fileID: 1205461599799858621, guid: 28eb1ec0d234c8d49b746c202b4fabd8,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 6
-      objectReference: {fileID: 0}
-    - target: {fileID: 1205461599799858621, guid: 28eb1ec0d234c8d49b746c202b4fabd8,
-        type: 3}
-      propertyPath: m_LocalScale.x
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1205461599799858621, guid: 28eb1ec0d234c8d49b746c202b4fabd8,
-        type: 3}
-      propertyPath: m_LocalScale.z
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 7034453876563550899, guid: 28eb1ec0d234c8d49b746c202b4fabd8,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 10
-      objectReference: {fileID: 0}
-    - target: {fileID: 8028647169396267673, guid: 28eb1ec0d234c8d49b746c202b4fabd8,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 9
-      objectReference: {fileID: 0}
-    - target: {fileID: 6599933181260147352, guid: 28eb1ec0d234c8d49b746c202b4fabd8,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 11
-      objectReference: {fileID: 0}
-    - target: {fileID: 6599933181260147352, guid: 28eb1ec0d234c8d49b746c202b4fabd8,
-        type: 3}
-      propertyPath: m_LocalScale.x
-      value: 4
-      objectReference: {fileID: 0}
-    - target: {fileID: 6599933181260147352, guid: 28eb1ec0d234c8d49b746c202b4fabd8,
-        type: 3}
-      propertyPath: m_LocalScale.z
-      value: 4
+      propertyPath: m_IsActive
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3512233768307141550, guid: 28eb1ec0d234c8d49b746c202b4fabd8,
         type: 3}
@@ -10583,11 +10539,6 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7781585145764726960, guid: 28eb1ec0d234c8d49b746c202b4fabd8,
-        type: 3}
-      propertyPath: m_IsActive
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8574603337716842063, guid: 28eb1ec0d234c8d49b746c202b4fabd8,
         type: 3}
       propertyPath: m_IsActive
       value: 0
@@ -10606,16 +10557,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_SizeDelta.y
       value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5555905691882334421, guid: 28eb1ec0d234c8d49b746c202b4fabd8,
-        type: 3}
-      propertyPath: turnPitch
-      value: 5
-      objectReference: {fileID: 0}
-    - target: {fileID: 5555905691882334421, guid: 28eb1ec0d234c8d49b746c202b4fabd8,
-        type: 3}
-      propertyPath: pitchSpeed
-      value: 15
       objectReference: {fileID: 0}
     - target: {fileID: 7246809434146495432, guid: 28eb1ec0d234c8d49b746c202b4fabd8,
         type: 3}
@@ -10636,6 +10577,66 @@ PrefabInstance:
         type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1205461599799858621, guid: 28eb1ec0d234c8d49b746c202b4fabd8,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 1205461599799858621, guid: 28eb1ec0d234c8d49b746c202b4fabd8,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1205461599799858621, guid: 28eb1ec0d234c8d49b746c202b4fabd8,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7034453876563550899, guid: 28eb1ec0d234c8d49b746c202b4fabd8,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 570438915209207995, guid: 28eb1ec0d234c8d49b746c202b4fabd8,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 2329687056888948350, guid: 28eb1ec0d234c8d49b746c202b4fabd8,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 8028647169396267673, guid: 28eb1ec0d234c8d49b746c202b4fabd8,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 7
+      objectReference: {fileID: 0}
+    - target: {fileID: 6599933181260147352, guid: 28eb1ec0d234c8d49b746c202b4fabd8,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: 6599933181260147352, guid: 28eb1ec0d234c8d49b746c202b4fabd8,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 6599933181260147352, guid: 28eb1ec0d234c8d49b746c202b4fabd8,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 5555905691882334421, guid: 28eb1ec0d234c8d49b746c202b4fabd8,
+        type: 3}
+      propertyPath: turnPitch
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5555905691882334421, guid: 28eb1ec0d234c8d49b746c202b4fabd8,
+        type: 3}
+      propertyPath: pitchSpeed
+      value: 15
       objectReference: {fileID: 0}
     - target: {fileID: 3039033051041562513, guid: 28eb1ec0d234c8d49b746c202b4fabd8,
         type: 3}
@@ -10669,27 +10670,27 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 28eb1ec0d234c8d49b746c202b4fabd8, type: 3}
---- !u!4 &7360550566265133025 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 1205461599799858621, guid: 28eb1ec0d234c8d49b746c202b4fabd8,
-    type: 3}
-  m_PrefabInstance: {fileID: 8547626818343617116}
-  m_PrefabAsset: {fileID: 0}
 --- !u!4 &2795169887814647243 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 5788591693250314135, guid: 28eb1ec0d234c8d49b746c202b4fabd8,
     type: 3}
   m_PrefabInstance: {fileID: 8547626818343617116}
   m_PrefabAsset: {fileID: 0}
---- !u!4 &6184461902093187112 stripped
+--- !u!4 &7360550566265133025 stripped
 Transform:
-  m_CorrespondingSourceObject: {fileID: 2543647688365849204, guid: 28eb1ec0d234c8d49b746c202b4fabd8,
+  m_CorrespondingSourceObject: {fileID: 1205461599799858621, guid: 28eb1ec0d234c8d49b746c202b4fabd8,
     type: 3}
   m_PrefabInstance: {fileID: 8547626818343617116}
   m_PrefabAsset: {fileID: 0}
 --- !u!1 &9031141000880245006 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 849574673130163026, guid: 28eb1ec0d234c8d49b746c202b4fabd8,
+    type: 3}
+  m_PrefabInstance: {fileID: 8547626818343617116}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &6184461902093187112 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2543647688365849204, guid: 28eb1ec0d234c8d49b746c202b4fabd8,
     type: 3}
   m_PrefabInstance: {fileID: 8547626818343617116}
   m_PrefabAsset: {fileID: 0}
@@ -10848,15 +10849,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: c9047090688c1c74fae6cdf1ef6b516e, type: 3}
---- !u!4 &8632392389049068363 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 400004, guid: c9047090688c1c74fae6cdf1ef6b516e,
-    type: 3}
-  m_PrefabInstance: {fileID: 8632392389048676815}
-  m_PrefabAsset: {fileID: 0}
 --- !u!198 &8632392389033864719 stripped
 ParticleSystem:
   m_CorrespondingSourceObject: {fileID: 19800000, guid: c9047090688c1c74fae6cdf1ef6b516e,
+    type: 3}
+  m_PrefabInstance: {fileID: 8632392389048676815}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &8632392389049068363 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 400004, guid: c9047090688c1c74fae6cdf1ef6b516e,
     type: 3}
   m_PrefabInstance: {fileID: 8632392389048676815}
   m_PrefabAsset: {fileID: 0}

--- a/AlmostRace-Capstone/Assets/Prefabs/Cars/VoidWasp/VoidWasp_2.0.prefab
+++ b/AlmostRace-Capstone/Assets/Prefabs/Cars/VoidWasp/VoidWasp_2.0.prefab
@@ -5868,7 +5868,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   selfHeatDamage: 0
-  boostSpeedPercentage: 0.5
+  boostSpeedPercentage: 50
+  maxBoostTurnAngle: 75
   healthLossActivateAmount: 25
   companions:
   - {fileID: 2055918776}
@@ -5902,6 +5903,7 @@ MonoBehaviour:
   turnRate: 50
   timeBetweenLaunch: 0.15
   hangTime: 0.25
+  maxLifeTime: 7
   hypeToGain: 5
 --- !u!1 &5757797024540854829
 GameObject:
@@ -11374,6 +11376,21 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 2543647688365849204, guid: 28eb1ec0d234c8d49b746c202b4fabd8,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 0.125
+      objectReference: {fileID: 0}
+    - target: {fileID: 2543647688365849204, guid: 28eb1ec0d234c8d49b746c202b4fabd8,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 0.125
+      objectReference: {fileID: 0}
+    - target: {fileID: 2543647688365849204, guid: 28eb1ec0d234c8d49b746c202b4fabd8,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 0.25
+      objectReference: {fileID: 0}
     - target: {fileID: 644788421544090394, guid: 28eb1ec0d234c8d49b746c202b4fabd8,
         type: 3}
       propertyPath: m_Name
@@ -11452,17 +11469,17 @@ PrefabInstance:
     - target: {fileID: 644788422693019630, guid: 28eb1ec0d234c8d49b746c202b4fabd8,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: -0.18910752
+      value: -0.14521314
       objectReference: {fileID: 0}
     - target: {fileID: 644788422693019630, guid: 28eb1ec0d234c8d49b746c202b4fabd8,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0.000000008411205
+      value: 0.000000028248497
       objectReference: {fileID: 0}
     - target: {fileID: 644788422693019630, guid: 28eb1ec0d234c8d49b746c202b4fabd8,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 1.3333334
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 644788422693019630, guid: 28eb1ec0d234c8d49b746c202b4fabd8,
         type: 3}
@@ -11472,47 +11489,17 @@ PrefabInstance:
     - target: {fileID: 644788422693019630, guid: 28eb1ec0d234c8d49b746c202b4fabd8,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: -0.00000011643887
+      value: -0.000000118101156
       objectReference: {fileID: 0}
     - target: {fileID: 644788422693019630, guid: 28eb1ec0d234c8d49b746c202b4fabd8,
         type: 3}
       propertyPath: m_LocalRotation.w
-      value: -0.9819564
+      value: -0.98940045
       objectReference: {fileID: 0}
-    - target: {fileID: 716463124009632865, guid: 28eb1ec0d234c8d49b746c202b4fabd8,
+    - target: {fileID: 7488727476820995678, guid: 28eb1ec0d234c8d49b746c202b4fabd8,
         type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8938214498588058289, guid: 28eb1ec0d234c8d49b746c202b4fabd8,
-        type: 3}
-      propertyPath: m_LocalScale.x
-      value: 0.3
-      objectReference: {fileID: 0}
-    - target: {fileID: 8938214498588058289, guid: 28eb1ec0d234c8d49b746c202b4fabd8,
-        type: 3}
-      propertyPath: m_LocalScale.z
-      value: 0.3
-      objectReference: {fileID: 0}
-    - target: {fileID: 8938214498588058289, guid: 28eb1ec0d234c8d49b746c202b4fabd8,
-        type: 3}
-      propertyPath: m_LocalScale.y
-      value: 0.35
-      objectReference: {fileID: 0}
-    - target: {fileID: 2543647688365849204, guid: 28eb1ec0d234c8d49b746c202b4fabd8,
-        type: 3}
-      propertyPath: m_LocalScale.x
-      value: 0.125
-      objectReference: {fileID: 0}
-    - target: {fileID: 2543647688365849204, guid: 28eb1ec0d234c8d49b746c202b4fabd8,
-        type: 3}
-      propertyPath: m_LocalScale.z
-      value: 0.125
-      objectReference: {fileID: 0}
-    - target: {fileID: 2543647688365849204, guid: 28eb1ec0d234c8d49b746c202b4fabd8,
-        type: 3}
-      propertyPath: m_LocalScale.y
-      value: 0.25
+      propertyPath: boostAccelerationMulti
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 3240311213283490686, guid: 28eb1ec0d234c8d49b746c202b4fabd8,
         type: 3}
@@ -11549,20 +11536,65 @@ PrefabInstance:
       propertyPath: boostAbilityRecharge
       value: 10
       objectReference: {fileID: 0}
-    - target: {fileID: 644788420753075452, guid: 28eb1ec0d234c8d49b746c202b4fabd8,
+    - target: {fileID: 8574603337716842063, guid: 28eb1ec0d234c8d49b746c202b4fabd8,
         type: 3}
-      propertyPath: m_RenderingPath
-      value: 3
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3512233768307141550, guid: 28eb1ec0d234c8d49b746c202b4fabd8,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7478375866446768871, guid: 28eb1ec0d234c8d49b746c202b4fabd8,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7781585145764726960, guid: 28eb1ec0d234c8d49b746c202b4fabd8,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8840104850272968325, guid: 28eb1ec0d234c8d49b746c202b4fabd8,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5145035194956675732, guid: 28eb1ec0d234c8d49b746c202b4fabd8,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5145035194956675732, guid: 28eb1ec0d234c8d49b746c202b4fabd8,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7246809434146495432, guid: 28eb1ec0d234c8d49b746c202b4fabd8,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7246809434146495432, guid: 28eb1ec0d234c8d49b746c202b4fabd8,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7246809434146495432, guid: 28eb1ec0d234c8d49b746c202b4fabd8,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7246809434146495432, guid: 28eb1ec0d234c8d49b746c202b4fabd8,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1205461599799858621, guid: 28eb1ec0d234c8d49b746c202b4fabd8,
         type: 3}
       propertyPath: m_RootOrder
       value: 7
-      objectReference: {fileID: 0}
-    - target: {fileID: 7488727476820995678, guid: 28eb1ec0d234c8d49b746c202b4fabd8,
-        type: 3}
-      propertyPath: boostAccelerationMulti
-      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 8028647169396267673, guid: 28eb1ec0d234c8d49b746c202b4fabd8,
         type: 3}
@@ -11589,26 +11621,6 @@ PrefabInstance:
       propertyPath: m_RootOrder
       value: 6
       objectReference: {fileID: 0}
-    - target: {fileID: 9098373548087876332, guid: 28eb1ec0d234c8d49b746c202b4fabd8,
-        type: 3}
-      propertyPath: m_ShowToolkit
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 9098373548087876332, guid: 28eb1ec0d234c8d49b746c202b4fabd8,
-        type: 3}
-      propertyPath: m_ShowCustomSorter
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 9098373548087876332, guid: 28eb1ec0d234c8d49b746c202b4fabd8,
-        type: 3}
-      propertyPath: volumeLayer.m_Bits
-      value: 29441793
-      objectReference: {fileID: 0}
-    - target: {fileID: 9098373548087876332, guid: 28eb1ec0d234c8d49b746c202b4fabd8,
-        type: 3}
-      propertyPath: antialiasingMode
-      value: 1
-      objectReference: {fileID: 0}
     - target: {fileID: 6599933181260147352, guid: 28eb1ec0d234c8d49b746c202b4fabd8,
         type: 3}
       propertyPath: m_LocalScale.x
@@ -11629,80 +11641,70 @@ PrefabInstance:
       propertyPath: m_RootOrder
       value: 8
       objectReference: {fileID: 0}
-    - target: {fileID: 2951899406841428011, guid: 28eb1ec0d234c8d49b746c202b4fabd8,
+    - target: {fileID: 8938214498588058289, guid: 28eb1ec0d234c8d49b746c202b4fabd8,
         type: 3}
-      propertyPath: m_IsActive
-      value: 0
+      propertyPath: m_LocalScale.x
+      value: 0.3
       objectReference: {fileID: 0}
-    - target: {fileID: 3512233768307141550, guid: 28eb1ec0d234c8d49b746c202b4fabd8,
+    - target: {fileID: 8938214498588058289, guid: 28eb1ec0d234c8d49b746c202b4fabd8,
         type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
+      propertyPath: m_LocalScale.z
+      value: 0.3
       objectReference: {fileID: 0}
-    - target: {fileID: 1472873719778039414, guid: 28eb1ec0d234c8d49b746c202b4fabd8,
+    - target: {fileID: 8938214498588058289, guid: 28eb1ec0d234c8d49b746c202b4fabd8,
         type: 3}
-      propertyPath: m_IsActive
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7478375866446768871, guid: 28eb1ec0d234c8d49b746c202b4fabd8,
-        type: 3}
-      propertyPath: m_IsActive
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7781585145764726960, guid: 28eb1ec0d234c8d49b746c202b4fabd8,
-        type: 3}
-      propertyPath: m_IsActive
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8574603337716842063, guid: 28eb1ec0d234c8d49b746c202b4fabd8,
-        type: 3}
-      propertyPath: m_IsActive
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8840104850272968325, guid: 28eb1ec0d234c8d49b746c202b4fabd8,
-        type: 3}
-      propertyPath: m_IsActive
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5145035194956675732, guid: 28eb1ec0d234c8d49b746c202b4fabd8,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5145035194956675732, guid: 28eb1ec0d234c8d49b746c202b4fabd8,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
+      propertyPath: m_LocalScale.y
+      value: 0.35
       objectReference: {fileID: 0}
     - target: {fileID: 5555905691882334421, guid: 28eb1ec0d234c8d49b746c202b4fabd8,
         type: 3}
       propertyPath: carType
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 1472873719778039414, guid: 28eb1ec0d234c8d49b746c202b4fabd8,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2951899406841428011, guid: 28eb1ec0d234c8d49b746c202b4fabd8,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 716463124009632865, guid: 28eb1ec0d234c8d49b746c202b4fabd8,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 1312355136754225343, guid: 28eb1ec0d234c8d49b746c202b4fabd8,
         type: 3}
       propertyPath: m_audioClip
       value: 
       objectReference: {fileID: 8300000, guid: ace73f68e3e2c24488e0a0073191f35b, type: 3}
-    - target: {fileID: 7246809434146495432, guid: 28eb1ec0d234c8d49b746c202b4fabd8,
+    - target: {fileID: 644788420753075452, guid: 28eb1ec0d234c8d49b746c202b4fabd8,
         type: 3}
-      propertyPath: m_AnchorMin.y
+      propertyPath: m_RenderingPath
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 9098373548087876332, guid: 28eb1ec0d234c8d49b746c202b4fabd8,
+        type: 3}
+      propertyPath: m_ShowToolkit
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 9098373548087876332, guid: 28eb1ec0d234c8d49b746c202b4fabd8,
+        type: 3}
+      propertyPath: m_ShowCustomSorter
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 7246809434146495432, guid: 28eb1ec0d234c8d49b746c202b4fabd8,
+    - target: {fileID: 9098373548087876332, guid: 28eb1ec0d234c8d49b746c202b4fabd8,
         type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
+      propertyPath: volumeLayer.m_Bits
+      value: 29441793
       objectReference: {fileID: 0}
-    - target: {fileID: 7246809434146495432, guid: 28eb1ec0d234c8d49b746c202b4fabd8,
+    - target: {fileID: 9098373548087876332, guid: 28eb1ec0d234c8d49b746c202b4fabd8,
         type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7246809434146495432, guid: 28eb1ec0d234c8d49b746c202b4fabd8,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
+      propertyPath: antialiasingMode
+      value: 1
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 28eb1ec0d234c8d49b746c202b4fabd8, type: 3}

--- a/AlmostRace-Capstone/Assets/Scripts/Abilities/Lux_Abilities/Lux_BoostAbility.cs
+++ b/AlmostRace-Capstone/Assets/Scripts/Abilities/Lux_Abilities/Lux_BoostAbility.cs
@@ -15,13 +15,19 @@ public class Lux_BoostAbility : CooldownHeatAbility
     private RaycastCar carInfo;
     private bool isBoosting = false;
 
-    [Range(0, 1)]
+    [Header("Movement Values")]
+    [Range(0, 100)]
+    [Tooltip("The percentage speed increase added to the top speed while boosting.")]
     public float boostSpeedPercentage;
 
+    [Tooltip("The percentage of the original maxTurnAngle the car is allowed during a boost.")]
+    [Range(0, 100)]
+    public float maxBoostTurnAngle;
+    private float originalMaxTurnAngle;
    //[Range(0, 100)]
    //public float boostTopSpeedPercentage;
 
-    [Header("Jet engine effect")]
+    [Header("Visuals: Jet engine effect")]
     [Tooltip("Set Lux booster particle effect")]
     public ParticleSystem jetParticles;
     public ParticleSystem jetParticles2;
@@ -39,6 +45,8 @@ public class Lux_BoostAbility : CooldownHeatAbility
     {
         carInfo = gameObject.GetComponent<RaycastCar>();
         carHeatInfo = gameObject.GetComponent<CarHealthBehavior>();
+        originalMaxTurnAngle = carInfo.maxTurnAngle;
+
     }
 
     public override void ActivateAbility()
@@ -46,7 +54,7 @@ public class Lux_BoostAbility : CooldownHeatAbility
        if(!isBoosting)
         {
             isBoosting = true;
-            carInfo.setBoostSpeed(boostSpeedPercentage);
+            carInfo.setBoostSpeed(boostSpeedPercentage / 100);
             // Set the new jet particle speed
             var jpMain = jetParticles.main;
             var jpMain2 = jetParticles2.main;
@@ -58,8 +66,8 @@ public class Lux_BoostAbility : CooldownHeatAbility
             jpMain.startSpeed = jetIncrease;
             jpMain2.startSpeed = jetIncrease;
             jpMain3.startSpeed = jetIncrease;
-
-            AddHeat();
+            carInfo.maxTurnAngle = originalMaxTurnAngle * (maxBoostTurnAngle / 100);
+            //AddHeat();
         }
        
        //carInfo.SetBoostInfo(boostSpeedPercentage);              
@@ -78,11 +86,12 @@ public class Lux_BoostAbility : CooldownHeatAbility
         jpMain3.startSpeed = _originalJetSpeed2;
 
         isBoosting = false;
+        carInfo.maxTurnAngle = originalMaxTurnAngle;
     }
 
     protected override void AddHeat()
     {
-       carHeatInfo.DamageCarTrue(selfHeatDamage);
+      // carHeatInfo.DamageCarTrue(selfHeatDamage);
     }
 
 

--- a/AlmostRace-Capstone/Assets/Scripts/Abilities/PainTrain_Abilities/PainTrain_Boost.cs
+++ b/AlmostRace-Capstone/Assets/Scripts/Abilities/PainTrain_Abilities/PainTrain_Boost.cs
@@ -11,9 +11,25 @@ public class PainTrain_Boost : CooldownHeatAbility
     private bool isBoosting = false;
     public GameObject boostField;
     private PainTrain_BoostShock _boostFieldScript;
-    public float boostDamageRate;
-    public float boostDamage;
 
+    [Header("Movement Values")]
+
+    [Tooltip("The percentage speed increase added to the top speed while boosting.")]
+    [Range(0, 100)]
+    public float boostSpeedPercentage;
+
+    [Tooltip("The percentage of the original maxTurnAngle the car is allowed during a boost.")]
+    [Range(0, 100)]
+    public float maxBoostTurnAngle;
+
+    private float originalMaxTurnAngle;
+
+    [Tooltip("How often the boosts AOE damage happens each second. So a value of 2 means every 2 seconds, a value of .5 means every half second.")]
+    public float boostDamageRate;
+    [Tooltip("How much damage the AOE does")]
+    public float boostDamage;
+    
+    [Header("Visuals")]
     public float smallSize = 2f;
     public float mediumSize = 4;
     public float bigSize = 8;
@@ -21,8 +37,7 @@ public class PainTrain_Boost : CooldownHeatAbility
     public List<GameObject> vfxToActivate = new List<GameObject>();
     public List<ParticleSystem> boosterParticles = new List<ParticleSystem>();
 
-    [Range(0, 1)]
-    public float boostSpeedPercentage;
+
 
     // Start is called before the first frame update
     void Start()
@@ -33,6 +48,7 @@ public class PainTrain_Boost : CooldownHeatAbility
 
         carInfo = gameObject.GetComponent<RaycastCar>();
         AbilityOffOfCooldown();
+        originalMaxTurnAngle = carInfo.maxTurnAngle;
     }
 
     public override void ActivateAbility()
@@ -40,10 +56,12 @@ public class PainTrain_Boost : CooldownHeatAbility
         if (!isBoosting)
         {
             isBoosting = true;
-            carInfo.setBoostSpeed(boostSpeedPercentage);
+            carInfo.setBoostSpeed(boostSpeedPercentage / 100);
 
             boostField.SetActive(true);
+            carInfo.maxTurnAngle = originalMaxTurnAngle * (maxBoostTurnAngle / 100);
         }
+
         foreach(GameObject vfxObj in vfxToActivate)
         {
             vfxObj.SetActive(true);
@@ -57,6 +75,8 @@ public class PainTrain_Boost : CooldownHeatAbility
         boostField.SetActive(false);
 
         isBoosting = false;
+        carInfo.maxTurnAngle = originalMaxTurnAngle;
+
 
         foreach (GameObject vfxObj in vfxToActivate)
         {

--- a/AlmostRace-Capstone/Assets/Scripts/Abilities/VoidWasp_Abilities/VoidWasp_Boost.cs
+++ b/AlmostRace-Capstone/Assets/Scripts/Abilities/VoidWasp_Abilities/VoidWasp_Boost.cs
@@ -12,7 +12,19 @@ using UnityEngine;
 
 public class VoidWasp_Boost : CooldownHeatAbility
 {
-    [Range(0, 1)] public float boostSpeedPercentage;
+
+    [Header("Movement Values")]
+
+    [Tooltip("The percentage speed increase added to the top speed while boosting.")]
+    [Range(0, 100)] public float boostSpeedPercentage;
+
+    [Tooltip("The percentage of the original maxTurnAngle the car is allowed during a boost.")]
+    [Range(0, 100)]
+    public float maxBoostTurnAngle;
+
+    private float originalMaxTurnAngle;
+
+    [Header("Combat Values")]
     public float healthLossActivateAmount = 25;
     private float currentBoostPercentage;
     public GameObject[] companions;
@@ -24,6 +36,7 @@ public class VoidWasp_Boost : CooldownHeatAbility
     {
         carInfo = gameObject.GetComponent<RaycastCar>();
         carHeatInfo = gameObject.GetComponent<CarHealthBehavior>();
+        originalMaxTurnAngle = carInfo.maxTurnAngle;
     }
 
     public override void ActivateAbility()
@@ -31,8 +44,9 @@ public class VoidWasp_Boost : CooldownHeatAbility
         if(!isBoosting)
         {
             isBoosting = true;
-            currentBoostPercentage = boostSpeedPercentage;
+            currentBoostPercentage = (boostSpeedPercentage / 100);
             carInfo.setBoostSpeed(currentBoostPercentage);
+            carInfo.maxTurnAngle = originalMaxTurnAngle * (maxBoostTurnAngle / 100);
             for (int i = 0; i < companions.Length; i++)
             {
                 companions[i].SetActive(true);
@@ -71,7 +85,7 @@ public class VoidWasp_Boost : CooldownHeatAbility
                     }
                 }
             }
-            if (currentBoostPercentage <= boostSpeedPercentage * 0.50f)
+            if (currentBoostPercentage <= (boostSpeedPercentage/ 100) * 0.50f)
             {
                 DeactivateAbility();
             }
@@ -89,6 +103,8 @@ public class VoidWasp_Boost : CooldownHeatAbility
             Instantiate(explodeVFX, companions[i].transform.position, companions[i].transform.rotation);
             AudioManager.instance.Play("VoidWasp Companion Death", transform);
         }
+
+        carInfo.maxTurnAngle = originalMaxTurnAngle;
         isBoosting = false;
     }
 


### PR DESCRIPTION
In each boost code on each car (needed to be that way because of void wasp) there now exists a maxBoostTurnAngle variable that is a percentage of the actual maxTurnAngle and will be used by each individual car during boosting. Code has also been cleaned up and tooltips and headers added for ease of use.